### PR TITLE
Remove `bottle :unneeded`

### DIFF
--- a/Formula/nox.rb
+++ b/Formula/nox.rb
@@ -3,7 +3,6 @@ class Nox < Formula
   desc "A grand unified Elasticsearch infrastructure management cli"
   homepage ""
   version "0.1.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/procore/nox/releases/download/v0.1.4/nox_0.1.4_64-bit_macOS.tar.gz"


### PR DESCRIPTION
When running some brew commands, was getting the following warning output:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the procore/formulae tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/procore/homebrew-formulae/Formula/nox.rb:6
```

See also: https://0x.co/MHR9HK